### PR TITLE
Setting hostname failed if full hostname contains underscore. Which i…

### DIFF
--- a/include/start-container.sh
+++ b/include/start-container.sh
@@ -8,8 +8,8 @@ if [ $# -gt 1 ]; then
     exit 1
 fi
 
-# Always set the hostname to the FQDN name
-hostname $(hostname -f)
+# Always set the hostname to the FQDN name if available
+hostname $(hostname -f) || true
 
 if [ -n "$1" ]; then
     if [ -z "$VESPA_CONFIGSERVERS" ]; then


### PR DESCRIPTION
…t does if docker network is specified.
@jobergum 

Docker can contain underscore which the hostname command does not accept. 