### PR TITLE
Use latest version when building latest and the last rpm tag.

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -8,6 +8,6 @@ RUN yum-config-manager --add-repo https://copr.fedorainfracloud.org/coprs/g/vesp
 
 ADD include/start-container.sh /usr/local/bin/start-container.sh 
 
-RUN yum install -y vespa-6.140.53
+RUN yum install -y vespa
 
 ENTRYPOINT ["/usr/local/bin/start-container.sh"]

--- a/bin/tag-and-push-release.sh
+++ b/bin/tag-and-push-release.sh
@@ -10,7 +10,5 @@ fi
 
 readonly VERSION=$1
 
-sed -i.orig "s/^RUN.*yum.*install.*vespa-[0-9]\.[0-9]*\.[0-9]*.*/RUN yum install -y vespa-$VERSION/" Dockerfile
-git commit -am "Updated version to $VERSION"
 git tag -a -m "Release $VERSION" $VERSION
 git push --follow-tags


### PR DESCRIPTION
@bjorncs 

Due to master branch protection, we can't modify the master with deploy keys. Since we control the rpm build and trigger docker images after this we can use the last built vespa for latest and the tag.