### PR TITLE
Fixed typo in environment variable assignment

### DIFF
--- a/include/start-container.sh
+++ b/include/start-container.sh
@@ -33,7 +33,7 @@ if [ -n "$1" ]; then
             ;;
     esac
 else
-    export VESPA_CONFIG_SERVERS=$(hostname)
+    export VESPA_CONFIGSERVERS=$(hostname)
     /opt/vespa/bin/vespa-start-configserver
     /opt/vespa/bin/vespa-start-services
 fi


### PR DESCRIPTION
Value set for the VESPA_CONFIG_SERVERS environment variable gets ignored during startup. The environment variable VESPA_CONFIG_SERVERS should be VESPA_CONFIGSERVERS per the documentation specified in the populate_environment function in vespa/vespabase/src/common-env.sh and usage in defaults/src/vespa/defaults.cpp.

Pull request https://github.com/vespa-engine/vespa/pull/5429 fixes the same issue in the dev startup script code in the main vespa repository.