### PR TITLE
Do not start services when specifying to start configserver

### DIFF
--- a/include/start-container.sh
+++ b/include/start-container.sh
@@ -22,7 +22,6 @@ if [ -n "$1" ]; then
     case $1 in
         configserver)
             /opt/vespa/bin/vespa-start-configserver
-            /opt/vespa/bin/vespa-start-services
             ;;
         services)
             /opt/vespa/bin/vespa-start-services


### PR DESCRIPTION
(fallback is still to start both config server and services if no
argument is given)