### PR TITLE
ensure traps actually trigger

### DIFF
--- a/include/start-container.sh
+++ b/include/start-container.sh
@@ -50,4 +50,5 @@ else
     /opt/vespa/bin/vespa-start-services
 fi
 
-tail -f /dev/null
+tail -f /dev/null &
+wait


### PR DESCRIPTION
* the shell won't process signals while running the
  never-ending "tail -f /dev/null" command
* instead, run that in the background and wait for
  child exit or signal

I confirm that this contribution is made under the terms of the license found in the root directory of this repository's source tree and that I have the authority necessary to make this contribution on behalf of its copyright owner.

@toregge please review
@jobergum FYI
