### PR TITLE
Sleep instead of tailing file

### DIFF
--- a/include/start-container.sh
+++ b/include/start-container.sh
@@ -50,5 +50,5 @@ else
     /opt/vespa/bin/vespa-start-services
 fi
 
-tail -f /dev/null &
+sleep infinity &
 wait


### PR DESCRIPTION
`tail -f /dev/null` creates a inotify watch on `/dev/null`.

This may not be allowed, depending on what privileges the container has. For example, it fails with Podman (without `--privileged`):
```
$ podman run --rm --name vespa --pids-limit -1 --publish 8080:8080 --publish 19071:19071 docker.io/vespaengine/vespa
hostname: you must be root to change the host name
Running /opt/vespa/libexec/vespa/start-configserver
Creating data directory /opt/vespa/var/zookeeper/version-2
runserver(configserver) running with pid: 269
Running /opt/vespa/libexec/vespa/start-vespa-base.sh
Starting config proxy using tcp/c614bc1d3b22:19070 as config source(s)
runserver(configproxy) running with pid: 549
Waiting for config proxy to start
config proxy started after 1s (runserver pid 549)
runserver(config-sentinel) running with pid: 691
tail: cannot watch '/dev/null': Permission denied
```

@aressem 
