### PR TITLE
Revert "more likely to run with "localhost" here"

### DIFF
--- a/include/start-container.sh
+++ b/include/start-container.sh
@@ -60,7 +60,7 @@ if [ -n "$1" ]; then
     esac
 else
     if [ -z "$VESPA_CONFIGSERVERS" ]; then
-        export VESPA_CONFIGSERVERS="localhost"
+        export VESPA_CONFIGSERVERS=$(hostname)
     fi
     /opt/vespa/bin/vespa-start-configserver
     /opt/vespa/bin/vespa-start-services


### PR DESCRIPTION
This reverts commit 2088cc51cf4b6f002e935bd7aeffa194bbbabb8e.

Fixes issues with config server not starting when running quick start guide
@aressem @kkraune please review
@arnej27959 FYI