### PR TITLE
Set the vespa-cli directories to use /tmp as the vespa user do not ha…

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -40,6 +40,8 @@ LABEL org.opencontainers.image.authors="Vespa (https://vespa.ai)" \
 
 ENV VESPA_LOG_STDOUT="true"
 ENV VESPA_LOG_FORMAT="vespa"
+ENV VESPA_CLI_HOME=/tmp/.vespa
+ENV VESPA_CLI_CACHE_DIR=/tmp/.cache/vespa
 
 USER vespa
 


### PR DESCRIPTION
…ve permissions to write to /opt/vespa.

I confirm that this contribution is made under the terms of the license found in the root directory of this repository's source tree and that I have the authority necessary to make this contribution on behalf of its copyright owner.
