### PR TITLE
fix: update mend.yaml to exclude tag from project name

### DIFF
--- a/.github/workflows/mend.yaml
+++ b/.github/workflows/mend.yaml
@@ -43,8 +43,9 @@ jobs:
       run: |
         echo "Scanning image ${IMAGE}"
 
-        # Project is everything after the last slash (typically: vespa...:8)
+        # Project is everything after the last slash, excluding the tag
         MEND_PROJECT=${IMAGE##*/}
+        MEND_PROJECT=${MEND_PROJECT%:*}
         echo "Project: ${MEND_PROJECT}"
 
         # Application is everything before the last slash (typically: docker.io/vespaengine)


### PR DESCRIPTION
# What

Excludes the container image tag from the mend project name

## Why

Reduced the number of duplicate projects on mend