### PR TITLE
Support OpenShift arbitrary UIDs (restricted-v2 SCC)

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -40,7 +40,7 @@ ARG SOURCE_GITREF=v$VESPA_VERSION
 ADD include/start-container.sh /usr/local/bin/start-container.sh
 
 RUN groupadd -g 1000 vespa && \
-    useradd -u 1000 -g vespa -d /opt/vespa -s /sbin/nologin vespa
+    useradd -u 1000 -g vespa -G root -d /opt/vespa -s /sbin/nologin vespa
 
 RUN  --mount=type=bind,target=/files,source=.,ro \
     if [[ -d /files/rpms ]]; then echo -e "[vespa-rpms-local]\nname=Local Vespa RPMs\nbaseurl=file:///files/rpms/\nenabled=1\ngpgcheck=0" > /etc/yum.repos.d/vespa-rpms-local.repo; fi && \
@@ -48,6 +48,11 @@ RUN  --mount=type=bind,target=/files,source=.,ro \
     dnf clean all && \
     rm -f /etc/yum.repos.d/vespa-rpms-local.repo && \
     rm -rf /var/cache/dnf
+
+RUN chmod g+w /etc/passwd && \
+    chgrp -R 0 /opt/vespa/logs /opt/vespa/var /opt/vespa/secure /opt/vespa/var/zookeeper && \
+    chmod -R g+w /opt/vespa/logs /opt/vespa/var /opt/vespa/secure /opt/vespa/var/zookeeper && \
+    chgrp 0 /opt/vespa/tmp 2>/dev/null; chmod g+w /opt/vespa/tmp 2>/dev/null; true
 
 LABEL org.opencontainers.image.authors="Vespa (https://vespa.ai)" \
       org.opencontainers.image.description="Easily serve your big data - generate responses in milliseconds at any scale and with any traffic volume. Read more at the Vespa project https://vespa.ai" \

--- a/Dockerfile.minimal
+++ b/Dockerfile.minimal
@@ -6,7 +6,7 @@ ARG ROOTFS_INSTALL_DIR=/tmp_install
 
 # Add vespa user before installing the Vespa RPMs to get a fixed UID/GID
 RUN groupadd -g 1000 vespa && \
-    useradd -u 1000 -g vespa -d /opt/vespa -s /sbin/nologin vespa && \
+    useradd -u 1000 -g vespa -G root -d /opt/vespa -s /sbin/nologin vespa && \
     mkdir -p $ROOTFS_INSTALL_DIR/etc && \
     cp -a /etc/passwd /etc/group /etc/shadow $ROOTFS_INSTALL_DIR/etc
 
@@ -77,6 +77,13 @@ RUN (find $ROOTFS_INSTALL_DIR/usr -name "*gdb*"    | xargs rm -rf) && \
 RUN mkdir -p $ROOTFS_INSTALL_DIR/run/lock && \
     chroot $ROOTFS_INSTALL_DIR truncate --size 0 /etc/machine-id && \
     echo 'LANG=C.utf8' > $ROOTFS_INSTALL_DIR/etc/locale.conf
+
+# OpenShift compatibility: make writable dirs accessible by GID 0 (arbitrary UIDs)
+RUN chmod g+w $ROOTFS_INSTALL_DIR/etc/passwd && \
+    chgrp -R 0 $ROOTFS_INSTALL_DIR/opt/vespa/logs $ROOTFS_INSTALL_DIR/opt/vespa/var \
+               $ROOTFS_INSTALL_DIR/opt/vespa/secure $ROOTFS_INSTALL_DIR/opt/vespa/var/zookeeper && \
+    chmod -R g+w $ROOTFS_INSTALL_DIR/opt/vespa/logs $ROOTFS_INSTALL_DIR/opt/vespa/var \
+                 $ROOTFS_INSTALL_DIR/opt/vespa/secure $ROOTFS_INSTALL_DIR/opt/vespa/var/zookeeper
 
 # Build the image
 FROM scratch

--- a/include/start-container.sh
+++ b/include/start-container.sh
@@ -3,6 +3,15 @@
 
 set -e
 
+# OpenShift runs containers with arbitrary UIDs not present in /etc/passwd.
+# Inject a passwd entry so that utilities like 'id' and 'whoami' work.
+if ! whoami &>/dev/null 2>&1; then
+    if [ -w /etc/passwd ]; then
+        echo "vespa:x:$(id -u):0:Vespa:/opt/vespa:/bin/bash" >> /etc/passwd
+    fi
+    export VESPA_USER=vespa
+fi
+
 if [ $# -gt 1 ]; then
     echo "Allowed arguments to entrypoint are {configserver,services}."
     exit 1


### PR DESCRIPTION
## Summary

- Make Vespa container images compatible with OpenShift 4.20's default `restricted-v2` Security Context Constraint (SCC)
- Containers can now run under arbitrary UIDs assigned by OpenShift, with file access via GID 0 (root group)
- Entrypoint injects a `/etc/passwd` entry at runtime so standard utilities (`id`, `whoami`, Go's `user.Current()`) work

## Background: OpenShift SCCs and the root group

OpenShift uses [Security Context Constraints (SCCs)](https://docs.openshift.com/container-platform/4.20/authentication/managing-security-context-constraints.html) to control what pods can do at runtime. The default `restricted-v2` SCC enforces:

- **Arbitrary UID assignment**: Containers run as a random UID from a [namespace-specific range](https://docs.openshift.com/container-platform/4.20/openshift_images/create-images.html#use-uid_create-images) (e.g. `1000660000`+), not the UID specified via `USER` in the Dockerfile
- **GID 0 (root group)**: The arbitrary UID is always a member of the root group (GID 0). This is [by design](https://docs.openshift.com/container-platform/4.20/openshift_images/create-images.html#use-uid_create-images) — the root *group* is used as the access mechanism for arbitrary UIDs, while the root *user* (UID 0) remains prohibited
- **No privilege escalation**: `setuid()`/`setgid()` are blocked; `CAP_SETUID` and `CAP_SETGID` are dropped

As stated in the [OpenShift documentation](https://docs.openshift.com/container-platform/4.20/openshift_images/create-images.html#use-uid_create-images):

> *"The directories and files that are read from or written to by processes in the image should be owned by the root group and be read/writable by that group. Files to be executed should also have group execute permissions [...] because the container user is always a member of the root group, the container user can read and write these files."*

### Why root group ownership is safe

Using GID 0 as the group owner does **not** grant root privileges. It simply allows any UID assigned to the root group (which OpenShift always does) to read/write the directories. The actual user remains unprivileged — it cannot escalate to UID 0, bind privileged ports, or perform any root-level operations.

## Changes

### Dockerfiles (`Dockerfile`, `Dockerfile.minimal`)
- Added `-G root` to `useradd` so the `vespa` user is a member of the root group
- Made `/etc/passwd` group-writable (`chmod g+w`) to allow runtime UID injection
- Set root group ownership (`chgrp -R 0`) and group-write permissions (`chmod -R g+w`) on all writable directories: `/opt/vespa/logs`, `/opt/vespa/var`, `/opt/vespa/secure`, `/opt/vespa/var/zookeeper`

### Entrypoint (`include/start-container.sh`)
- Added passwd entry injection for arbitrary UIDs: when `whoami` fails (UID not in `/etc/passwd`), a `vespa` entry is appended mapping the current UID to GID 0
- Sets `VESPA_USER=vespa` so downstream scripts resolve correctly

## Companion PR

The corresponding Vespa application code changes (user-switching, ownership validation, startup scripts) are in [vespa-engine/vespa](https://github.com/vespa-engine/vespa).

## Test plan

- [ ] Build image and run with `docker run --user=$(shuf -i 1000000-1999999 -n1):0` to simulate OpenShift
- [ ] Verify `whoami` returns `vespa` inside container after entrypoint passwd injection
- [ ] Verify all directories under `/opt/vespa/var` and `/opt/vespa/logs` are writable
- [ ] Verify `vespa-start-configserver` and `vespa-start-services` succeed under arbitrary UID
- [ ] Confirm no regression when running as default `vespa` user (UID 1000)
- [ ] Test `Dockerfile.minimal` build with same arbitrary UID scenario

🤖 Generated with [Claude Code](https://claude.com/claude-code)